### PR TITLE
fix: distinguish between exact and regex matches

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-schema.json

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,9 +45,10 @@ this:
 
 The rules engine needs to support the following functionality:
 
-- Matching of a trust anchor ("match")
+- Exact matching of a trust anchor ("match")
   - **Example A**: The trust anchor is an AWS KMS Key with the ARN
     `arn:aws:kms:eu-west-1:123456789012:alias/my-team`.
+- Matching of a trust anchor via regular expressions ("match regex")
   - **Example B**: The trust anchor matches the regular expression
     `^arn:aws:kms:eu-(central|west)-1:123456789012:.*$`.
 - Matching of all rules ("and" / "all of")
@@ -95,19 +96,22 @@ definitions:
     description: Defines a single matching rule.
     oneOf:
       - not:
-          required: [anyOf, match, not, oneOf]
+          required: [anyOf, match, matchRegex, not, oneOf]
         required: [allOf]
       - not:
-          required: [allOf, match, not, oneOf]
+          required: [allOf, match, matchRegex, not, oneOf]
         required: [anyOf]
       - not:
-          required: [allOf, anyOf, not, oneOf]
+          required: [allOf, anyOf, matchRegex, not, oneOf]
         required: [match]
       - not:
-          required: [allOf, anyOf, match, oneOf]
+          required: [allOf, anyOf, match, not, oneOf]
+        required: [matchRegex]
+      - not:
+          required: [allOf, anyOf, match, matchRegex, oneOf]
         required: [not]
       - not:
-          required: [allOf, anyOf, match, not]
+          required: [allOf, anyOf, match, matchRegex, not]
         required: [oneOf]
     properties:
       allOf:
@@ -120,9 +124,10 @@ definitions:
         $ref: "#/definitions/rules"
         description: Asserts that at least one of the nested rules matches.
       match:
-        description: >-
-          Defines the pattern to match trust anchors against. Can be an exact
-          string or a regular expression.
+        description: Specifies a trust anchor that has to match exactly.
+        type: string
+      matchRegex:
+        description: Defines a regular expression to match trust anchors against.
         type: string
       not:
         $ref: "#/definitions/rule"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type Rule struct {
 	AllOf       []Rule `json:"allOf,omitempty"`
 	AnyOf       []Rule `json:"anyOf,omitempty"`
 	Match       string `json:"match,omitempty"`
+	MatchRegex  string `json:"matchRegex,omitempty"`
 	Not         *Rule  `json:"not,omitempty"`
 	OneOf       []Rule `json:"oneOf,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -51,7 +52,6 @@ func Load(filePath string) (*Config, error) {
 
 // Validate validates a configuration.
 func Validate(config *Config) error {
-
 	for _, singleRule := range config.Rules {
 		if err := ValidateRule(&singleRule); err != nil {
 			return err
@@ -60,8 +60,6 @@ func Validate(config *Config) error {
 
 	return nil
 }
-
-//
 
 func bool2int(b bool) int {
 	if b {
@@ -72,8 +70,8 @@ func bool2int(b bool) int {
 
 // ValidateRule validates a single rule.
 func ValidateRule(rule *Rule) error {
-
 	matchConditions := (bool2int(rule.Match != "") +
+		bool2int(rule.MatchRegex != "") +
 		bool2int(rule.Not != nil) +
 		bool2int(len(rule.AllOf) > 0) +
 		bool2int(len(rule.AnyOf) > 0) +

--- a/schema.json
+++ b/schema.json
@@ -6,11 +6,40 @@
       "additionalProperties": false,
       "description": "Defines a single matching rule.",
       "oneOf": [
-        { "not": { "required": ["anyOf", "match", "not", "oneOf"] }, "required": ["allOf"] },
-        { "not": { "required": ["allOf", "match", "not", "oneOf"] }, "required": ["anyOf"] },
-        { "not": { "required": ["allOf", "anyOf", "not", "oneOf"] }, "required": ["match"] },
-        { "not": { "required": ["allOf", "anyOf", "match", "oneOf"] }, "required": ["not"] },
-        { "not": { "required": ["allOf", "anyOf", "match", "not"] }, "required": ["oneOf"] }
+        {
+          "not": {
+            "required": ["anyOf", "match", "matchRegex", "not", "oneOf"]
+          },
+          "required": ["allOf"]
+        },
+        {
+          "not": {
+            "required": ["allOf", "match", "matchRegex", "not", "oneOf"]
+          },
+          "required": ["anyOf"]
+        },
+        {
+          "not": {
+            "required": ["allOf", "anyOf", "matchRegex", "not", "oneOf"]
+          },
+          "required": ["match"]
+        },
+        {
+          "not": { "required": ["allOf", "anyOf", "match", "not", "oneOf"] },
+          "required": ["matchRegex"]
+        },
+        {
+          "not": {
+            "required": ["allOf", "anyOf", "match", "matchRegex", "oneOf"]
+          },
+          "required": ["not"]
+        },
+        {
+          "not": {
+            "required": ["allOf", "anyOf", "match", "matchRegex", "not"]
+          },
+          "required": ["oneOf"]
+        }
       ],
       "properties": {
         "allOf": {
@@ -26,7 +55,11 @@
           "description": "Asserts that at least one of the nested rules matches."
         },
         "match": {
-          "description": "Defines the pattern to match trust anchors against. Can be an exact string or a regular expression.",
+          "description": "Specifies a trust anchor that has to match exactly.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "Defines a regular expression to match trust anchors against.",
           "type": "string"
         },
         "not": {


### PR DESCRIPTION
This change proposes to split out the regex matching functionality into a dedicated `matchRegex` rule. The rationale behind this change is that, by having `match` support both exact and regex matching it can lead to very surprising behaviour that is not obvious to the user.

An example: with the presence of regex matching, `match: foo` would match `foo`, **but it also would match** `foobar` and `barfoo`. This means that it would match more trust anchors than anticipated, and that in turn can be a security issue.

To achieve true exact matching, one would need to use `match: ^foo$`, but that's really verbose and easy to forget.

By making `match` just perform plain exact string matching and have `matchRegex` for use cases that require more complicated matching behaviour via regular expressions the footgun above can be avoided.