### PR TITLE
fix(config): load YAML instead of JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module github.com/Bonial-International-GmbH/sops-compliance-checker
 
 go 1.22.8
+
+require (
+	github.com/goccy/go-yaml v1.14.3
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.14.3 h1:8tVD+aqqPLWisSEhM+6wWoiURWXCx6BwaTKS6ZeITgM=
+github.com/goccy/go-yaml v1.14.3/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,10 +2,11 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/goccy/go-yaml"
 )
 
 // Config represents the configuration for the sops-compliance-checker.
@@ -33,13 +34,18 @@ func Load(filePath string) (*Config, error) {
 	}
 	defer file.Close()
 
-	bytes, err := io.ReadAll(file)
+	return LoadReader(file)
+}
+
+// LoadReader loads the configuration from an io.Reader.
+func LoadReader(reader io.Reader) (*Config, error) {
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
 
 	var config Config
-	if err := json.Unmarshal(bytes, &config); err != nil {
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,16 @@ package config
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestLoadConfig(t *testing.T) {
+	config, err := Load("testdata/config.yaml")
+	require.NoError(t, err)
+	require.Len(t, config.Rules, 1)
+	require.Len(t, config.Rules[0].AllOf, 3)
+}
 
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -1,0 +1,29 @@
+---
+rules:
+  # All rules must match. This will automatically reject excess trust anchors
+  # not matching any of the nested rules.
+  - allOf:
+      - description: Disaster recovery key must be present.
+        match: age1u79ltfzz5k79ex4mpl3r76p2532xex4mpl3z7vttctudr6gedn6ex4mpl3
+      - anyOf:
+          - allOf:
+              - match: arn:aws:kms:eu-central-1:123456789012:alias/team-foo
+              - match: arn:aws:kms:eu-west-1:123456789012:alias/team-foo
+            description: Regional keys of team-foo.
+          - allOf:
+              - match: arn:aws:kms:eu-central-1:123456789012:alias/team-bar
+              - match: arn:aws:kms:eu-west-1:123456789012:alias/team-bar
+            description: Regional keys of team-bar.
+        description: The AWS KMS key pair of at least one team must be present.
+      - oneOf:
+          - allOf:
+              - match: arn:aws:kms:eu-central-1:123456789012:alias/production-cicd
+              - match: arn:aws:kms:eu-west-1:123456789012:alias/production-cicd
+            description: Regional production keys.
+          - allOf:
+              - match: arn:aws:kms:eu-central-1:123456789012:alias/staging-cicd
+              - match: arn:aws:kms:eu-west-1:123456789012:alias/staging-cicd
+            description: Regional staging keys.
+        description: >-
+          The AWS KMS key pair of exactly one deployment target environment
+          must be present.


### PR DESCRIPTION
Changes:

- Parse config files as YAML.
- Added simple config loading test for the example from the design document.
- I also added the `LoadReader` function to load configuration from an `io.Reader` as we'll need that in some followup PR to support tests.