### PR TITLE
ci: improve megalinter configuration

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter/flavors/go@v8
+        uses: oxsecurity/megalinter/flavors/go@v8.1.0
         env:
           GOTOOLCHAIN: auto
           VALIDATE_ALL_CODEBASE: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/coverage.txt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+---
+linters:
+  enable:
+    - gocritic
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - typecheck
+    - unused
+    - whitespace
+run:
+  timeout: 10m

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -2,5 +2,8 @@ DISABLE:
   - COPYPASTE
   - HTML
   - SPELL
-GO_GOLANGCI_LINT_ARGUMENTS: --timeout=5m
+
+DISABLE_LINTERS:
+  - GO_REVIVE # We're running revive via golangci-lint already.
+
 REPOSITORY_TRIVY_ARGUMENTS: --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --ignorefile .trivyignore.yaml


### PR DESCRIPTION
This makes it easier to run the go linters locally but just running `golangci-lint run`. It also bumps megalinter to v8.1.0 which adds support for go 1.23.

Additionally it puts the `coverage.txt` generated by `make coverage` on gitignore.