### PR TITLE
chore: rename project to `sops-check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /coverage.txt
-sops-compliance-checker
+sops-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ FROM alpine:3.20
 
 RUN apk --update --no-cache add ca-certificates
 
-COPY --from=builder /src/sops-compliance-checker /sops-compliance-checker
+COPY --from=builder /src/sops-check /sops-check
 
 USER nobody
 
-ENTRYPOINT ["/sops-compliance-checker"]
+ENTRYPOINT ["/sops-check"]

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 TEST_FLAGS ?= -race
 PKGS       ?= $(shell go list ./... | grep -v /vendor/)
-BINARY     := sops-compliance-checker
-IMAGE      ?= sops-compliance-checker
+BINARY     := sops-check
+IMAGE      ?= sops-check
 TAG        ?= latest
 
 .PHONY: all clean
@@ -13,7 +13,7 @@ help:
 	@grep -E '^[a-zA-Z-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "[32m%-12s[0m %s\n", $$1, $$2}'
 
 .PHONY: build
-build: ## sops-compliance-checker
+build: ## sops-check
 	go build \
 		-ldflags "-s -w" \
 		-o $(BINARY) \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sops-compliance-checker
+# sops-check
 
 We are following a design-first approach, please take a look at [the design document](docs/design.md) and we are happy to hear your thoughts about it.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: sops-compliance-checker
+  name: sops-check
   description: |
     Tool that looks for SOPS files in a repository
     and makes sure that they are configured in the desired fashion

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,9 +1,9 @@
 # Design
 
-This document explains the purpose of the `sops-compliance-checker` and also
-documents the functional and non-functional requirements we have, as well as
-the details about design decisions we took. It assumes familarity with
-[SOPS][sops] and the concepts that it uses.
+This document explains the purpose of `sops-check` and also documents the
+functional and non-functional requirements we have, as well as the details
+about design decisions we took. It assumes familarity with [SOPS][sops] and the
+concepts that it uses.
 
 ## Purpose
 
@@ -27,9 +27,9 @@ anchors that are in use. Some questions that to be answered could be:
 - How can we prevent the usage of certain trust anchors in the presence of
   others (mutual exclusivity)?
 
-To answer these questions for any given SOPS file, the
-`sops-compliance-checker` needs to be flexible enough to process a set of
-user-defined rules which indicate success or failure.
+To answer these questions for any given SOPS file, `sops-check` needs to be
+flexible enough to process a set of user-defined rules which indicate success
+or failure.
 
 ## Functional Requirements
 
@@ -143,12 +143,12 @@ definitions:
     items:
       $ref: "#/definitions/rule"
     type: array
-description: Schema of the sops-compliance-checker configuration file
+description: Schema of the sops-check configuration file
 properties:
   rules:
     $ref: "#/definitions/rules"
     description: A list of matching rules.
-title: sops-compliance-checker configuration
+title: sops-check configuration
 type: object
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Bonial-International-GmbH/sops-compliance-checker
+module github.com/Bonial-International-GmbH/sops-check
 
 go 1.23
 

--- a/internal/rules/compile.go
+++ b/internal/rules/compile.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/Bonial-International-GmbH/sops-compliance-checker/pkg/config"
+	"github.com/Bonial-International-GmbH/sops-check/pkg/config"
 )
 
 // Compile takes a slice of rule configurations and compiles it into a single

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Bonial-International-GmbH/sops-compliance-checker/internal/rules"
-	"github.com/Bonial-International-GmbH/sops-compliance-checker/pkg/config"
+	"github.com/Bonial-International-GmbH/sops-check/internal/rules"
+	"github.com/Bonial-International-GmbH/sops-check/pkg/config"
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestUI(t *testing.T) {
 		testCfg, err := loadTestConfig(path)
 		require.NoError(t, err)
 
-		// Load sops-compliance-checker configuration.
+		// Load sops-check configuration.
 		reader := strings.NewReader(testCfg.Config)
 		cfg, err := config.LoadReader(reader)
 		require.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Package main provides the entrypoint for the sops-compliance-checker executable.
+// Package main provides the entrypoint for the sops-check executable.
 package main
 
 import (

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: sops-compliance-checker
+site_name: sops-check
 site_description: |
   Tool that looks for SOPS files in a repository
   and makes sure that they are configured in the desired fashion

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Package config provides utility functions for the sops-compliance-checker.
+// Package config provides utility functions for the sops-check.
 package config
 
 import (
@@ -9,7 +9,7 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-// Config represents the configuration for the sops-compliance-checker.
+// Config represents the configuration for the sops-check.
 type Config struct {
 	Rules []Rule `json:"rules"`
 }

--- a/schema.json
+++ b/schema.json
@@ -84,13 +84,13 @@
       "type": "array"
     }
   },
-  "description": "Schema of the sops-compliance-checker configuration file",
+  "description": "Schema of the sops-check configuration file",
   "properties": {
     "rules": {
       "$ref": "#/definitions/rules",
       "description": "A list of matching rules."
     }
   },
-  "title": "sops-compliance-checker configuration",
+  "title": "sops-check configuration",
   "type": "object"
 }


### PR DESCRIPTION
Replaces `sops-compliance-checker` with `sops-check` everywhere in the code base.

Once this is merged I'm going to rename the repository itself.